### PR TITLE
Fix: App Store redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ if (result.status == VersionarteResult.appInactive) {
 
 ## 🔗 Launching the stores
 
-To launch the App Store on iOS and Play Store on Android, use the `Versionarte.launchStore` method by providing it with `appleAppId` (int) for App Store and `androidPackageName` (String) for Play Store.
+To launch the App Store on iOS and Play Store on Android, use the `Versionarte.launchStore` method by providing it with `appStoreUrl` (String) for App Store and `androidPackageName` (String) for Play Store.
 
 ```dart
 Versionarte.launchStore(
-    appleAppId: 123456789,
-    androidPackageName: 'com.example.app',
+    appStoreUrl: 'https://apps.apple.com/az/app/librokit-books-quotes-ai/id6472595860',
+    androidPackageName: 'app.librokit',
 );
 ```
 

--- a/lib/src/versionarte.dart
+++ b/lib/src/versionarte.dart
@@ -115,7 +115,7 @@ class Versionarte {
   /// If launch the store for the platform is not supported returns `false`.
   ///
   /// Parameters:
-  ///   - `appleAppId` (int): The app ID of the app on the App Store (iOS).
+  ///   - `appStoreUrl` (String): The URL of the app on the App Store (iOS)
   ///     If the app is not published on the App Store, pass `null`.
   ///   - `androidPackageName` (String): The package name of the app (Android)
   ///     retrieved automatically from the device's `package_info` package
@@ -124,7 +124,7 @@ class Versionarte {
   ///   - A `Future<bool>` that indicates whether the URL was successfully
   ///     launched or not.
   static Future<bool> launchStore({
-    required int? appleAppId,
+    String? appStoreUrl,
     String? androidPackageName,
   }) async {
     const mode = LaunchMode.externalApplication;
@@ -138,16 +138,15 @@ class Versionarte {
         ),
         mode: mode,
       );
-    } else if (Platform.isIOS) {
+    } else if (Platform.isIOS && appStoreUrl != null) {
       return launchUrl(
-        Uri.parse(
-          'https://apps.apple.com/app/id$appleAppId',
-        ),
+        Uri.parse(appStoreUrl),
         mode: mode,
       );
     } else {
       logVersionarte(
-          'Opening store for ${Platform.operatingSystem} platform is not supported.');
+        'Opening store for ${Platform.operatingSystem} platform is not supported.',
+      );
       return false;
     }
   }


### PR DESCRIPTION
Fixed App Store redirection by replacing `appleAppId` with `appStoreUrl` directly to be safe.