### PR TITLE
feat: Added support for build number comparison

### DIFF
--- a/lib/src/models/versionarte_comparator.dart
+++ b/lib/src/models/versionarte_comparator.dart
@@ -1,0 +1,26 @@
+/// This Dart code defines an enumeration called `VersionarteComparator` with three possible values:
+/// `versionOnly`, `versionAndBuildNumber`, and `buildNumberOnly`. This enum can be used to represent
+/// different comparison modes for versioning or build numbers in a Dart program.
+enum VersionarteComparator {
+  /// In Dart, `versionOnly` is a value defined in the `VersionarteComparator` enumeration. It
+  /// represents one of the possible comparison modes for versioning. When using this enum,
+  /// `versionOnly` can be used to specify that only the version part of a version number should be
+  /// considered during comparisons or operations.
+  /// Example: 1.0.0 < 1.0.1
+  versionOnly,
+
+  /// The `versionAndBuildNumber` value in the `VersionarteComparator` enumeration represents a
+  /// comparison mode where both the version and build number parts of a version number are considered
+  /// during comparisons or operations. This means that when using this mode, both the version and build
+  /// number components of a version number will be taken into account when determining the order or
+  /// equality of two version numbers.
+  // Example: 1.0.0 < 1.0.1+1
+  versionAndBuildNumber,
+
+  /// The `buildNumberOnly` value in the `VersionarteComparator` enumeration represents a comparison
+  /// mode where only the build number part of a version number is considered during comparisons or
+  /// operations. This means that when using this mode, only the build number component of a version
+  /// number will be taken into account when determining the order or equality of two version numbers.
+  /// Example: 1.0.1+1 < 1.0.1+2 (this will only compare the build number thus +1 and +2, ignoring the version)
+  buildNumberOnly,
+}

--- a/lib/src/providers/remote_config_versionarte_provider.dart
+++ b/lib/src/providers/remote_config_versionarte_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:firebase_remote_config/firebase_remote_config.dart';
+import 'package:versionarte/src/models/versionarte_comparator.dart';
 import 'package:versionarte/src/utilities/logger.dart';
 import 'package:versionarte/versionarte.dart';
 
@@ -34,7 +35,12 @@ class RemoteConfigVersionarteProvider extends VersionarteProvider {
     this.keyName = 'versionarte',
     this.initializeInternally = true,
     this.remoteConfigSettings,
-  });
+
+    /// The line `VersionarteComparator comparator = VersionarteComparator.versionOnly` in the
+    /// `RemoteConfigVersionarteProvider` class is defining a parameter `comparator` with a default value
+    /// of `VersionarteComparator.versionOnly`.
+    VersionarteComparator comparator = VersionarteComparator.versionOnly,
+  }) : super(comparator: comparator);
 
   /// Fetches the JSON uploaded to Firebase Remote Config and decodes it into an instance of
   /// [DistributionManifest].

--- a/lib/src/providers/restful_versionarte_provider.dart
+++ b/lib/src/providers/restful_versionarte_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:versionarte/src/models/versionarte_comparator.dart';
 import 'package:versionarte/src/utilities/logger.dart';
 import 'package:versionarte/versionarte.dart';
 
@@ -22,7 +23,12 @@ class RestfulVersionarteProvider extends VersionarteProvider {
   const RestfulVersionarteProvider({
     required this.url,
     this.headers,
-  });
+
+    /// The line `VersionarteComparator comparator = VersionarteComparator.versionOnly,` in the
+    /// `RestfulVersionarteProvider` class is defining a parameter `comparator` of type
+    /// `VersionarteComparator` with a default value of `VersionarteComparator.versionOnly`.
+    VersionarteComparator comparator = VersionarteComparator.versionOnly,
+  }) : super(comparator: comparator);
 
   /// Sends an HTTP GET request to the RESTful API and decodes the response body into a [DistributionManifest] object.
   ///

--- a/lib/src/providers/versionarte_provider.dart
+++ b/lib/src/providers/versionarte_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:versionarte/src/models/versionarte_comparator.dart';
 import 'package:versionarte/versionarte.dart';
 
 /// An interface for a server-side store versioning information provider.
@@ -10,7 +11,20 @@ import 'package:versionarte/versionarte.dart';
 /// a [DistributionManifest] object or null if the versioning information cannot be retrieved.
 abstract class VersionarteProvider {
   /// Constructs a [VersionarteProvider].
-  const VersionarteProvider();
+  const VersionarteProvider({
+    /// In the `VersionarteProvider` abstract class constructor, `this.comparator =
+    /// VersionarteComparator.versionOnly,` is setting a default value for the `comparator` field. If no
+    /// value is provided for `comparator` when creating an instance of a class that implements
+    /// `VersionarteProvider`, it will default to `VersionarteComparator.versionOnly`. This ensures that
+    /// the `comparator` field is initialized with a default value if not explicitly provided during
+    /// object creation.
+    this.comparator = VersionarteComparator.versionOnly,
+  });
+
+  /// Determines the comparison mode for versioning or build numbers.
+  /// By default, it's set to `versionOnly`.
+  /// See [VersionarteComparator] for all possible values.
+  final VersionarteComparator comparator;
 
   /// Returns the store versioning information from a remote data source.
   ///

--- a/lib/src/versionarte.dart
+++ b/lib/src/versionarte.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:versionarte/src/models/versionarte_comparator.dart';
 import 'package:versionarte/src/utilities/logger.dart';
 import 'package:versionarte/src/utilities/pretty_json.dart';
 import 'package:versionarte/versionarte.dart';
@@ -70,17 +71,27 @@ class Versionarte {
             Version.parse(storeDetails.version.minimum);
         final Version latestVersion =
             Version.parse(storeDetails.version.latest);
-
-        final int minimumDifference = platformVersion.compareTo(minimumVersion);
-        final int latestDifference = platformVersion.compareTo(latestVersion);
-
-        final VersionarteStatus status = minimumDifference.isNegative
-            ? VersionarteStatus.forcedUpdate
-            : latestDifference.isNegative
-                ? VersionarteStatus.outdated
-                : VersionarteStatus.upToDate;
-
-        return VersionarteResult(status, manifest: manifest);
+        return switch (versionarteProvider.comparator) {
+          VersionarteComparator.versionOnly => _checkByVersionOnly(
+              latestVersion: latestVersion,
+              minimumVersion: minimumVersion,
+              platformVersion: platformVersion,
+              manifest: manifest,
+            ),
+          VersionarteComparator.versionAndBuildNumber =>
+            _checkByVersionAndBuildNumber(
+              latestVersion: latestVersion,
+              minimumVersion: minimumVersion,
+              platformVersion: platformVersion,
+              manifest: manifest,
+            ),
+          VersionarteComparator.buildNumberOnly => _checkByBuildNumberOnly(
+              latestVersion: latestVersion,
+              minimumVersion: minimumVersion,
+              platformVersion: platformVersion,
+              manifest: manifest,
+            ),
+        };
       }
     } on FormatException catch (e) {
       final error = versionarteProvider is RemoteConfigVersionarteProvider
@@ -129,5 +140,177 @@ class Versionarte {
       Uri.parse(url),
       mode: LaunchMode.externalApplication,
     );
+  }
+
+  /// The function `_checkByVersionOnly` compares the platform version with the latest and minimum
+  /// versions to determine if an update is required.
+  ///
+  /// Args:
+  ///   latestVersion (Version): The `latestVersion` parameter represents the most recent version
+  /// available for a particular software or application.
+  ///   minimumVersion (Version): The `minimumVersion` parameter represents the minimum required version
+  /// that the platform must have in order to function properly.
+  ///   platformVersion (Version): The `platformVersion` parameter is the version of the platform or
+  /// system that you are checking against. It is compared with the `latestVersion` and `minimumVersion`
+  /// to determine the status of the version in relation to these two versions.
+  ///   manifest (DistributionManifest): The code snippet you provided is a method named
+  /// `_checkByVersionOnly` that takes in several parameters including `latestVersion`,
+  /// `minimumVersion`, `platformVersion`, and an optional parameter `manifest` of type
+  /// `DistributionManifest`.
+  ///
+  /// Returns:
+  ///   The function `_checkByVersionOnly` is returning a `VersionarteResult` object based on the
+  /// comparison of the `platformVersion` with the `minimumVersion` and `latestVersion`. The returned
+  /// `VersionarteResult` object contains a `VersionarteStatus` value indicating whether the platform
+  /// version requires a forced update, is outdated, or is up to date. The `manifest` parameter is also
+  /// included
+  static VersionarteResult _checkByVersionOnly(
+      {required Version latestVersion,
+      required Version minimumVersion,
+      required Version platformVersion,
+      DistributionManifest? manifest}) {
+    final int minimumDifference = platformVersion.compareTo(minimumVersion);
+    final int latestDifference = platformVersion.compareTo(latestVersion);
+    return switch (minimumDifference) {
+      _ when minimumDifference.isNegative => VersionarteResult(
+          VersionarteStatus.forcedUpdate,
+          manifest: manifest,
+        ),
+      _ when latestDifference.isNegative => VersionarteResult(
+          VersionarteStatus.outdated,
+          manifest: manifest,
+        ),
+      _ => VersionarteResult(
+          VersionarteStatus.upToDate,
+          manifest: manifest,
+        ),
+    };
+  }
+
+  /// The function `_checkByVersionAndBuildNumber` compares the platform version with the latest and
+  /// minimum versions to determine the update status.
+  ///
+  /// Args:
+  ///   latestVersion (Version): The code snippet you provided is a method that checks the version and
+  /// build number of a platform against the latest version and minimum version. Based on the
+  /// comparisons, it returns a `VersionarteResult` object with a corresponding `VersionarteStatus`.
+  ///   minimumVersion (Version): The `minimumVersion` parameter represents the minimum version that your
+  /// platform should have in order to function properly. This function `_checkByVersionAndBuildNumber`
+  /// compares the platform version with the minimum version and the latest version to determine the
+  /// status of the platform version. It also considers the build numbers of the platform
+  ///   platformVersion (Version): The `platformVersion` parameter represents the version of the platform
+  /// you are working with. It is compared to the `latestVersion` and `minimumVersion` to determine the
+  /// status of the version and build number. The function `_checkByVersionAndBuildNumber` calculates the
+  /// differences between the platform version and the
+  ///   manifest (DistributionManifest): The code snippet you provided is a method that checks the
+  /// version and build number of a platform against the latest version and minimum version. Based on the
+  /// comparisons, it returns a `VersionarteResult` object with a corresponding `VersionarteStatus`.
+  ///
+  /// Returns:
+  ///   The function `_checkByVersionAndBuildNumber` is returning a `VersionarteResult` object based on
+  /// the comparison of the platform version with the latest version and minimum version. The returned
+  /// `VersionarteResult` object contains a `VersionarteStatus` indicating whether the platform version
+  /// requires a forced update, is outdated, or is up to date. The `manifest` parameter is also included
+  /// in the returned object
+  static VersionarteResult _checkByVersionAndBuildNumber(
+      {required Version latestVersion,
+      required Version minimumVersion,
+      required Version platformVersion,
+      DistributionManifest? manifest}) {
+    final int minimumDifference = platformVersion.compareTo(minimumVersion);
+    final int latestDifference = platformVersion.compareTo(latestVersion);
+    final int platformBuild = _extractBuildNumber(platformVersion);
+    final int latestBuild = _extractBuildNumber(latestVersion);
+    return switch (minimumDifference) {
+      _ when minimumDifference.isNegative => VersionarteResult(
+          VersionarteStatus.forcedUpdate,
+          manifest: manifest,
+        ),
+      _ when latestDifference.isNegative => VersionarteResult(
+          VersionarteStatus.outdated,
+          manifest: manifest,
+        ),
+      _ when platformBuild < latestBuild => VersionarteResult(
+          VersionarteStatus.outdated,
+          manifest: manifest,
+        ),
+      _ => VersionarteResult(
+          VersionarteStatus.upToDate,
+          manifest: manifest,
+        ),
+    };
+  }
+
+  /// This Dart function extracts the build number from a Version object, returning 0 if no build number
+  /// is found.
+  ///
+  /// Args:
+  ///   version (Version): The `_extractBuildNumber` function takes a `Version` object as a parameter.
+  /// The function extracts the build number from the `Version` object and returns it as an integer. If
+  /// the build number is not present or cannot be parsed as an integer, the function returns 0.
+  ///
+  /// Returns:
+  ///   The method `_extractBuildNumber` returns an integer value, which is either the last build number
+  /// extracted from the `Version` object or 0 if the build number is empty or cannot be parsed as an
+  /// integer.
+  static int _extractBuildNumber(Version version) {
+    if (version.build.isEmpty) return 0;
+    final lastBuildPart = version.build.lastOrNull.toString();
+    final number = int.tryParse(lastBuildPart);
+    return number ?? 0;
+  }
+
+  /// The function `_checkByBuildNumberOnly` compares the build numbers of different versions to
+  /// determine the status of the platform version.
+  ///
+  /// Args:
+  ///   latestVersion (Version): The `latestVersion` parameter represents the latest version of the
+  /// software.
+  ///   minimumVersion (Version): The `minimumVersion` parameter represents the minimum version that
+  /// your platform should have. In the provided code snippet, the build number is extracted from this
+  /// version to compare it with the platform's build number. If the platform's build number is lower
+  /// than the minimum build number, the result will indicate a forced
+  ///   platformVersion (Version): The `_checkByBuildNumberOnly` function compares the build numbers of
+  /// the platform version, latest version, and minimum version to determine the status of the version
+  /// artefact. It then returns a `VersionarteResult` based on the comparisons.
+  ///   manifest (DistributionManifest): The code snippet you provided is a method named
+  /// `_checkByBuildNumberOnly` that takes in several parameters including `latestVersion`,
+  /// `minimumVersion`, `platformVersion`, and an optional parameter `manifest` of type
+  /// `DistributionManifest`.
+  ///
+  /// Returns:
+  ///   The function `_checkByBuildNumberOnly` returns a `VersionarteResult` object based on the
+  /// comparison of build numbers extracted from the input versions. The returned `VersionarteResult`
+  /// object contains a `VersionarteStatus` indicating whether the platform version requires a forced
+  /// update, is outdated, or is up to date. The `manifest` parameter is also included in the returned
+  /// result.
+  static VersionarteResult _checkByBuildNumberOnly(
+      {required Version latestVersion,
+      required Version minimumVersion,
+      required Version platformVersion,
+      DistributionManifest? manifest}) {
+    final int platformBuild = _extractBuildNumber(platformVersion);
+    final int latestBuild = _extractBuildNumber(latestVersion);
+    final int minimumBuild = _extractBuildNumber(latestVersion);
+    final int minimumBuildDifference = platformBuild.compareTo(minimumBuild);
+    final int latestBuildDifference = platformBuild.compareTo(latestBuild);
+    return switch (minimumBuildDifference) {
+      _ when minimumBuildDifference.isNegative => VersionarteResult(
+          VersionarteStatus.forcedUpdate,
+          manifest: manifest,
+        ),
+      _ when latestBuildDifference.isNegative => VersionarteResult(
+          VersionarteStatus.outdated,
+          manifest: manifest,
+        ),
+      _ when platformBuild < latestBuild => VersionarteResult(
+          VersionarteStatus.outdated,
+          manifest: manifest,
+        ),
+      _ => VersionarteResult(
+          VersionarteStatus.upToDate,
+          manifest: manifest,
+        ),
+    };
   }
 }


### PR DESCRIPTION
### ✨ Feature: Add `VersionarteComparator` Enum for Flexible Version Comparison

This PR introduces the `VersionarteComparator` enum, which provides flexible comparison strategies for versioning logic.

#### 🚀 What’s New

* **`VersionarteComparator` enum** with three modes:

  * `versionOnly`: Compares only the semantic version (`major.minor.patch`).
  * `versionAndBuildNumber`: Compares both semantic version and build metadata (`+build`).
  * `buildNumberOnly`: Compares only the build metadata, ignoring the semantic version.

#### 🧠 Why This Matters

This abstraction allows consumers of the versioning system to configure comparison behavior based on their specific needs—whether strict SemVer, build-aware updates, or build-only comparisons for CI/CD pipelines or app rollout control.

#### 📌 Usage Example

```dart
final comparator = VersionarteComparator.versionAndBuildNumber;
// Logic will compare both semantic version and build number
```
