### PR TITLE
Make logging optional

### DIFF
--- a/lib/src/utilities/logger.dart
+++ b/lib/src/utilities/logger.dart
@@ -1,13 +1,14 @@
 import 'dart:developer';
 
 import 'package:flutter/foundation.dart';
+import 'package:versionarte/src/versionarte.dart';
 
 void logVersionarte(
   String message, {
   Object? error,
   StackTrace? stackTrace,
 }) {
-  if (!kReleaseMode) {
+  if (!kReleaseMode && Versionarte.enableLogging) {
     log(
       message,
       name: 'versionarte',

--- a/lib/src/versionarte.dart
+++ b/lib/src/versionarte.dart
@@ -20,18 +20,27 @@ class Versionarte {
     return _packageInfo!;
   }
 
+  /// Internal flag to control logging. Set via [check] parameter.
+  static bool _enableLogging = true;
+
+  /// Whether logging is currently enabled.
+  static bool get enableLogging => _enableLogging;
+
   /// Checks app's versioning and availability status.
   ///
   /// Parameters:
   /// - versionarteProvider: A [VersionarteProvider] instance to retrieve
   /// [DistributionManifest] stored remotely.
+  /// - enableLogging: Whether to print debug logs. Defaults to `true`.
   ///
   /// Returns:
   /// - A [Future] that resolves to a [VersionarteResult] instance which contains
   /// the versioning and availability status of the app.
   static Future<VersionarteResult> check({
     required VersionarteProvider versionarteProvider,
+    bool enableLogging = true,
   }) async {
+    _enableLogging = enableLogging;
     try {
       final PackageInfo info = await packageInfo;
       final Version platformVersion = Version.parse(info.version);


### PR DESCRIPTION
I didn't like having the debug console showing the versionarte check logs every time it called firebase remote config, so I've added an optional parameter to the `.check()` method that allows users to disable logging.

Usage:
```dart
final VersionarteResult result = await Versionarte.check(
    versionarteProvider: RemoteConfigVersionarteProvider(),
    enableLogging: false,
);
```